### PR TITLE
Feature: Add -s --skip flags.

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -38,6 +38,7 @@ type Options struct {
 	Path     string `json:"path"`
 	Append   bool   `json:"append"`
 	Bulleted bool   `json:"bulleted"`
+	Skip     int    `json:"skip"`
 	ShowHelp bool   `json:"show_help"`
 }
 
@@ -52,6 +53,8 @@ func ConfigureOptions(fs *flag.FlagSet, args []string) (*Options, error) {
 	fs.BoolVar(&opts.Append, "append", true, "Append to markdown after <!--toc--> or write to stdout")
 	fs.BoolVar(&opts.Bulleted, "b", true, "Write as bulleted, or write as numbered list")
 	fs.BoolVar(&opts.Bulleted, "bulleted", true, "Write as bulleted, or write as numbered list")
+	fs.IntVar(&opts.Skip, "s", 0, "Skip the first given number of headers ")
+	fs.IntVar(&opts.Skip, "skip", 0, "Skip the first given number of headers ")
 	fs.BoolVar(&opts.ShowHelp, "h", false, "Show help message")
 	fs.BoolVar(&opts.ShowHelp, "help", false, "Show help message")
 

--- a/pkg/toc/toc.go
+++ b/pkg/toc/toc.go
@@ -38,6 +38,7 @@ func Run() {
 	toc.Options.Path = opts.Path
 	toc.Options.Bulleted = opts.Bulleted
 	toc.Options.Append = opts.Append
+	toc.Options.Skip = opts.Skip
 
 	toc.logic()
 }

--- a/pkg/toc/toc.go
+++ b/pkg/toc/toc.go
@@ -69,7 +69,11 @@ func (t *toc) logic() {
 }
 
 func (t *toc) String() (s string) {
-	for _, v := range t.Content {
+	if t.Options.Skip >= len(t.Content) {
+		color.Red("ERROR: skip value is bigger than the length of table of contents")
+		os.Exit(1)
+	}
+	for _, v := range t.Content[t.Options.Skip:] {
 		s += v
 	}
 

--- a/pkg/toc/vars.go
+++ b/pkg/toc/vars.go
@@ -11,6 +11,7 @@ type tocConfig struct {
 	Path     string
 	Bulleted bool
 	Append   bool
+	Skip     int
 }
 
 type toc struct {


### PR DESCRIPTION
This PR adds support for specifying skip option for first n header.

`-s <int>`
`--skip <int>`

Using the `--skip 1` flag for the markdown file below should preserve this output:

Markdown file:
```md
# Test

# Actual header

# Actual header two
```

Output
```
- [Actual header](#actual-header)
- [Actual header two](#actual-header-two)
```




// closes: #4