### PR TITLE
fix: update go module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module toc
+module github.com/ycd/toc
 
 go 1.15
 


### PR DESCRIPTION
currently the tool can't be installed using `go install` due to mismatch of the path

fixes #11
