### PR TITLE
Fix import pathes

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"toc/pkg/toc"
+	"github.com/ycd/toc/pkg/toc"
 )
 
 func main() {

--- a/pkg/toc/toc.go
+++ b/pkg/toc/toc.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"toc/config"
+	"github.com/ycd/toc/config"
 
 	"github.com/fatih/color"
 	"github.com/yuin/goldmark"


### PR DESCRIPTION
The fix proposed by #12 was incomplete. The package is still not installable by `go install`.

Error message so far:
```
Downloading github.com/ycd/toc@main
go: downloading github.com/ycd/toc v0.3.1-0.20220115220700-b4b973079058
github.com/ycd/toc imports
        toc/pkg/toc: package toc/pkg/toc is not in GOROOT (/usr/lib/go/src/toc/pkg/toc)
```